### PR TITLE
Fix passing directory argument

### DIFF
--- a/eml2mbox.rb
+++ b/eml2mbox.rb
@@ -210,7 +210,7 @@ end
     # Extract specified directory with emls and the target archive (if any)
     emlDir = "."     # default if not specified
     emlDir = ARGV[0] if ARGV[0]!=nil
-    mboxArchive = emlDir+"/archive.mbox"    # default if not specified
+    mboxArchive = "archive.mbox"    # default if not specified
     mboxArchive = ARGV[1] if ARGV[1] != nil
 
     # Show specified settings


### PR DESCRIPTION
I got `No such file or directory` errors whenever trying to pass a directory as argument to this script. It turns out that since `Dir.chdir` is called [here](https://github.com/yardenac/eml2mbox/blob/master/eml2mbox.rb#L222), the later use at [this line](https://github.com/yardenac/eml2mbox/blob/master/eml2mbox.rb#L213) seems incorrect. Since we have already changed directory to the one specified, only `archive.mbox` should be passed to `File.new`.
